### PR TITLE
Fix unit tests and dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,9 +12,14 @@ Imports:
     DT,
     magrittr,
     purrr,
-    tidyr (>= 1.0.0)
+    tidyr (>= 1.0.0),
+    slackteams (>= 0.1.2),
+    threads
 RoxygenNote: 7.0.2
 URL: https://github.com/r4ds/mentordash
 BugReports: https://github.com/r4ds/mentordash/issues
 Suggests: 
     testthat
+Remotes: 
+    yonicd/slackteams
+    yonicd/threads

--- a/R/app_server.R
+++ b/R/app_server.R
@@ -16,7 +16,7 @@
   question_channels <- setNames(question_channels, question_channels)
   ## Read in Conversations ----
   convos <- lapply(question_channels, function(channel) {
-    threads::get_conversations(limit = 1000, channel = channel)
+    threads::conversations(limit = 1000, channel = channel)
   })
   ## Response to Tibble ----
   convos_tbl <- purrr::map_df(convos, .tidy_convo, .id = 'channel') %>%
@@ -76,7 +76,7 @@ get_permalink <- function(channel,
 }
 
 .tidy_convo <- function(convo){
-  y <- purrr::map_df(convo$messages,.f=function(x) {
+  y <- purrr::map_df(convo,.f=function(x) {
     if(is.null(x$client_msg_id))
       x$client_msg_id <- NA_character_
 

--- a/app.R
+++ b/app.R
@@ -1,0 +1,6 @@
+# the text "shinyApp" in this comment is needed
+# to tell RStudio to add the green Run App Button
+# options( "golem.app.prod" = TRUE)
+
+pkgload::load_all()
+run_app()

--- a/tests/testthat/test-golem-recommended.R
+++ b/tests/testthat/test-golem-recommended.R
@@ -3,12 +3,12 @@ context("golem tests")
 library(golem)
 
 test_that("app ui", {
-  ui <- app_ui()
+  ui <- .ui_main()
   expect_shinytaglist(ui)
 })
 
 test_that("app server", {
-  server <- app_server
+  server <- .app_server
   expect_is(server, "function")
 })
 


### PR DESCRIPTION
This PR aligns the function names in the unit tests with the function names in the app. It also adds an App.R file so that RStudio adds the little "Run App" button (it needs to find the word "shinyApp" somewhere in that file to do so. Furthermore, the dependencies on github packages (slackteams and threads) are now explicitely stated and some API changes in those implemented.