### PR TITLE
Add encryption.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@ $run_dev.*
 ^CODE_OF_CONDUCT\.md$
 ^app\.R$
 ^rsconnect$
+^\.secret$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .RData
 .Ruserdata
 rsconnect/*
+.secret

--- a/R/run_app.R
+++ b/R/run_app.R
@@ -7,7 +7,7 @@
 #'   of this app.
 #'
 #' @export
-run_app <- function(local = FALSE, ...) {
+run_app <- function(local = interactive(), ...) {
   if (local) {
     site_url <- "http://127.0.0.1:4242/"
   } else {

--- a/app.R
+++ b/app.R
@@ -8,5 +8,11 @@ pkgload::load_all(
   attach_testthat = FALSE,
   quiet = TRUE
 )
+
+shinyslack_key <- readLines(".secret", 1)
+Sys.setenv(
+  shinyslack_key = shinyslack_key
+)
+
 options( "golem.app.prod" = TRUE)
 mentordash::run_app() # add parameters here (if any)


### PR DESCRIPTION
Only impacts deployment.

If you're using this locally, you'll need to save a .secret file, which should have 1 line with 32 random characters. `stringi::stri_rand_strings(1, 32)` can produce a suitable string.